### PR TITLE
Refactoring JSON comparison

### DIFF
--- a/app/helpers/manageiq/consumption/data_utils_helper.rb
+++ b/app/helpers/manageiq/consumption/data_utils_helper.rb
@@ -1,0 +1,22 @@
+#
+# Helper for data converters
+#
+# Allows the user to find interact with JSON and compare thems
+#
+#
+
+module ManageIQ::Consumption
+  module DataUtilsHelper
+    def self.is_included_in?(context, test)
+      # Validating that one JSON is completely included in the other
+      # Only to be called with JSON!
+      return false if test.nil? || context.nil?
+      result = true
+      test = {} if test.empty?
+      HashDiff.diff(context, test).each do |x|
+        result = false if (x[0] == '+' || x[0] == '~')
+      end
+      return result
+    end
+  end
+end

--- a/app/models/manageiq/consumption/showback_price_plan.rb
+++ b/app/models/manageiq/consumption/showback_price_plan.rb
@@ -1,4 +1,5 @@
 class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
+
   self.table_name = 'showback_price_plans'
   has_many :showback_rates, :dependent => :destroy, :inverse_of => :showback_price_plan
   belongs_to :resource, :polymorphic => true
@@ -21,10 +22,7 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
     # For each group, select the one applying
     rates_hash.each do |_, xvalue|
       xvalue.each do |rate|
-        # delete one hash from the other, so if it is empty
-        result_hash = rate.screener
-        result_hash.extract!(event.context || Hash.new())
-        next unless result_hash == {}
+        next unless ManageIQ::Consumption::DataUtilsHelper.is_included_in? event.context, rate.screener
         # TODO Find the tier (can be more than one)
         # Calculate the measure applicable to each tier
         measure = event.get_measure(rate.category, rate.dimension)

--- a/spec/factories/showback_event.rb
+++ b/spec/factories/showback_event.rb
@@ -3,8 +3,8 @@ FactoryGirl.define do
     association :resource, :factory => :vm, :strategy => :build_stubbed
     start_time                4.hours.ago
     end_time                  1.hour.ago
-    context                   {}
-    data                      {}
+    context                   { { } }
+    data                      { { } }
 
     trait :with_tags_in_context do
       context { { "tag"=>{"environment"=>["test"] } } }

--- a/spec/helpers/data_utils_helper_spec.rb
+++ b/spec/helpers/data_utils_helper_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+# Specs in this file have access to a helper object that includes
+# the UnitsConverterHelper. For example:
+#
+# describe ApplicationHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+
+RSpec.describe ManageIQ::Consumption::DataUtilsHelper, type: :helper do
+  let(:json_1) { JSON.parse '{ "tag": { "uno": 1, "dos": 2, "tres": 3, "cuatro": { "cinco": 5, "seis": 6} } }' }
+  let(:json_2) { JSON.parse '{ "tag": { "cuatro": { "cinco": 5, "seis": 6 } } }' }
+  let(:json_3) { JSON.parse '{ "cuatro": { "cinco": 5, "seis": 6, "siete": 7 } }' }
+  let(:json_4) { JSON.parse '{ "siete": { "ocho": 8, "nueve": 9 } }' }
+
+  context "#is_included_in?" do
+    it "returns false if nil context or test" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?nil, "").to be false
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in? "", nil).to be false
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in? nil, nil).to be false
+    end
+
+    it "context and test are independent" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?json_1, json_4).to be false
+    end
+
+    it "context includes the test fully" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?json_1, json_2).to be true
+    end
+
+    it "content includes half of the test" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?json_1, json_3).to be false
+    end
+
+    it "content is empty" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?"", json_3).to be false
+    end
+
+    it "test is empty" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?json_1, "").to be true
+    end
+
+    it "contest and test are emtpy" do
+      expect(ManageIQ::Consumption::DataUtilsHelper.is_included_in?json_1, "").to be true
+    end
+  end
+end

--- a/spec/models/showback_price_plan_spec.rb
+++ b/spec/models/showback_price_plan_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         rate.dimension = 'max_number_of_cpu'
         rate.save
         # Rating now should return the value
-        expect(plan.calculate_cost(event)).to eq(Money.new(0))
+        expect(plan.calculate_cost(event)).to eq(fixed_rate + event.data['CPU']['max_number_of_cpu'] * variable_rate )
       end
 
       it 'calculates costs when more than one rate applies' do
@@ -154,7 +154,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         rate2.category  = 'CPU'
         rate2.save
         # Rating now should return the value
-        expect(plan.calculate_cost(event)).to eq(Money.new(rate.fixed_rate + (event.data['CPU']['average'] *rate.variable_rate)))
+        expect(plan.calculate_cost(event)).to eq(rate.fixed_rate + rate2.fixed_rate + event.data['CPU']['average'] * rate.variable_rate + event.data['CPU']['max_number_of_cpu'] * rate2.variable_rate)
       end
 
     end


### PR DESCRIPTION
The original comparison failed when there was a complicated screener or context.

This uses HashDiff to make sure that one JSON is inside the other using a proper comparison strategy