### PR TITLE
improving tests and new rate

### DIFF
--- a/app/models/manageiq/consumption/showback_price_plan.rb
+++ b/app/models/manageiq/consumption/showback_price_plan.rb
@@ -17,12 +17,12 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
     calculate_total_cost_input(event.resource.type, event.data, event.time_span, event.month_duration, event.context)
   end
 
-  def calculate_total_cost_input(category, data, time_span, cycle_duration, context)
+  def calculate_total_cost_input(resource_type, data, time_span, cycle_duration, context)
     # Accumulator
     tc = Money.new(0)
     # For each measure type in ShowbackUsageType, I need to find the rates applying to the different dimensions
     # If there is a rate associated to it, we call it with a measure (that can be 0)
-    ManageIQ::Consumption::ShowbackUsageType.where(category: category).each do |usage|
+    ManageIQ::Consumption::ShowbackUsageType.where(category: resource_type).each do |usage|
       usage.dimensions.each do |dim|
         rates = showback_rates.where(category: usage.category, dimension: "#{usage.measure}##{dim}")
         rates.each do |r|

--- a/app/models/manageiq/consumption/showback_price_plan.rb
+++ b/app/models/manageiq/consumption/showback_price_plan.rb
@@ -14,22 +14,7 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
   # Returns the total accumulated costs for all rates that apply
   ###################################################################
   def calculate_total_cost(event)
-    # Accumulator
-    tc = Money.new(0)
-    # For each measure type in ShowbackUsageType, I need to find the rates applying to the different dimensions
-    # If there is a rate associated to it, we call it with a measure (that can be 0
-    ManageIQ::Consumption::ShowbackUsageType.where(category: event.resource.type).each do |usage|
-      usage.dimensions.each do |dim|
-        rates = showback_rates.where(category: usage.category, dimension: "#{usage.measure}##{dim}")
-        rates.each do |r|
-          next unless (ManageIQ::Consumption::DataUtilsHelper.is_included_in? event.context, r.screener) &&
-                      (event.resource_type.include? r.category)
-          measure = event.get_measure(usage.measure, dim)
-          tc += r.rate(measure, event)
-        end
-      end
-    end
-    tc
+    calculate_total_cost_input(event.resource.type, event.data, event.time_span, event.month_duration, event.context)
   end
 
   def calculate_total_cost_input(category, data, time_span, cycle_duration, context)
@@ -41,9 +26,8 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
       usage.dimensions.each do |dim|
         rates = showback_rates.where(category: usage.category, dimension: "#{usage.measure}##{dim}")
         rates.each do |r|
-          next unless (ManageIQ::Consumption::DataUtilsHelper.is_included_in? context, r.screener) &&
-              (event.resource_type.include? r.category)
-          val = data[measure][dimension] if ( data && data[measure])
+          next unless (ManageIQ::Consumption::DataUtilsHelper.is_included_in? context, r.screener)
+          val = data[usage.measure][dim] if ( data && data[usage.measure])
           tc += r.rate_with_values(val, time_span, cycle_duration)
         end
       end

--- a/app/models/manageiq/consumption/showback_rate.rb
+++ b/app/models/manageiq/consumption/showback_rate.rb
@@ -29,23 +29,23 @@ class ManageIQ::Consumption::ShowbackRate < ApplicationRecord
 
   private
 
-  def occurrence(_value, time_span, month_duration)
+  def occurrence(_value, time_span, cycle_duration)
     # Returns fixed_cost + variable_cost prorated on time
     # total_time = calculate_total_time(event)
     # [event.fixed_cost, variable_cost * (end_time - start_time) / total_time]
-    fixed_rate + (variable_rate * time_span / month_duration)
+    fixed_rate + (variable_rate * time_span / cycle_duration)
   end
 
-  def duration(value, time_span, month_duration)
+  def duration(value, time_span, cycle_duration)
     # Returns fixed_cost + event_measure * variable_cost * (end_time - start_time) / total_time
     # total_time = calculate_total_time(event)
     # [event.fixed_cost, event_measure * (event.end_time - event.start_time) / total_time]
-    (fixed_rate * time_span / month_duration) + (value * variable_rate * time_span / month_duration)
+    (fixed_rate * time_span / cycle_duration) + (value * variable_rate * time_span / cycle_duration)
   end
 
-  def quantity(value, time_span, month_duration)
+  def quantity(value, time_span, cycle_duration)
     # event.fixed_cost + variable_cost * event
     # [event.fixed_cost, event_measure * variable_cost]
-    (fixed_rate * time_span / month_duration) + (value * variable_rate)
+    (fixed_rate * time_span / cycle_duration) + (value * variable_rate)
   end
 end

--- a/spec/models/showback_charge_spec.rb
+++ b/spec/models/showback_charge_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackCharge, :type => :model do
     end
 
     let(:event) do
-      FactoryGirl.build(:showback_event,
+      FactoryGirl.build_stubbed(:showback_event,
                         :with_vm_data,
                         :full_month)
     end
@@ -122,8 +122,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackCharge, :type => :model do
     context 'without price_plan' do
       it 'calculates cost using default price plan' do
         rate1
-        event.save
-        event.reload
+        event
         charge.save
         expect(event.data).not_to be_nil # making sure that the default is not empty
         expect(ManageIQ::Consumption::ShowbackPricePlan.count).to eq(1)
@@ -135,8 +134,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackCharge, :type => :model do
       it 'calculates cost using price plan' do
         rate1
         rate2
-        event.save
-        event.reload
+        event
         charge.save
         expect(event.data).not_to be_nil
         plan2
@@ -151,8 +149,6 @@ RSpec.describe ManageIQ::Consumption::ShowbackCharge, :type => :model do
       it 'raises an error if the plan provider is not working' do
         rate1
         rate2
-        event.save
-        event.reload
         charge.save
         expect(event.data).not_to be_nil
         expect(ManageIQ::Consumption::ShowbackPricePlan.count).to eq(2)

--- a/spec/models/showback_price_plan_spec.rb
+++ b/spec/models/showback_price_plan_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
     end
 
     context 'rating with no context' do
-      let(:event)          { FactoryGirl.build(:showback_event, :with_vm_data, :full_month) }
+      let(:resource)       { FactoryGirl.create(:vm) }
+      let(:event)          { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, resource: resource) }
       let(:fixed_rate)     { Money.new(11) }
       let(:variable_rate)  { Money.new(7) }
       let(:fixed_rate2)    { Money.new(5) }
@@ -83,6 +84,17 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         expect(plan.calculate_total_cost(event)).to eq(Money.new(0))
       end
 
+      it 'calculates costs when rate is not found and event data' do
+        rate.category = 'not-found'
+        rate.save
+        category = event.resource.type
+        data = event.data
+        time_span = event.time_span
+        cycle_duration = event.month_duration
+        context = event.context
+        expect(plan.calculate_total_cost_input(category, data, time_span, cycle_duration, context)).to eq(plan.calculate_total_cost(event))
+      end
+
       it 'calculates costs with one rate' do
         event.save
         event.reload
@@ -113,7 +125,8 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
     end
 
     context 'rating with context' do
-      let(:event) { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, :with_tags_in_context) }
+      let(:resource)      { FactoryGirl.create(:vm) }
+      let(:event)         { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, :with_tags_in_context, resource: resource) }
       let(:fixed_rate)    { Money.new(11) }
       let(:variable_rate) { Money.new(7) }
       let(:dimension)     { 'CPU#average' }


### PR DESCRIPTION
Changing the calculations to make sure that the rates that are applied are the same kind of the event, and not other.

Changed the UsageType search to find only rates of the defined category (i.e.: 'Vm' or 'Container' or 'Service')

Added a new function to ShowbackPool to make sure that we can call rate with only data and not with an event from the database.

Updated the tests to cope with this.

Changed event generator due to some problems with the event refresh when the factory was used out of the box.