### PR TITLE
Use managed tags only

### DIFF
--- a/app/models/manageiq/consumption/showback_event.rb
+++ b/app/models/manageiq/consumption/showback_event.rb
@@ -93,7 +93,7 @@ class ManageIQ::Consumption::ShowbackEvent < ApplicationRecord
     else
       self.context["tag"] = {} unless self.context.has_key?("tag")
     end
-    resource.tags.each do |tag|
+    resource.tagged_with(:ns => '/managed').each do |tag|
       category = tag.classification.category
       self.context["tag"][category] = [] unless self.context["tag"].has_key?(category)
       self.context["tag"][category] << tag.classification.name unless self.context["tag"][category].include?(tag.classification.name)

--- a/app/models/manageiq/consumption/showback_event.rb
+++ b/app/models/manageiq/consumption/showback_event.rb
@@ -94,6 +94,7 @@ class ManageIQ::Consumption::ShowbackEvent < ApplicationRecord
       self.context["tag"] = {} unless self.context.has_key?("tag")
     end
     resource.tagged_with(:ns => '/managed').each do |tag|
+      next unless tag.classification
       category = tag.classification.category
       self.context["tag"][category] = [] unless self.context["tag"].has_key?(category)
       self.context["tag"][category] << tag.classification.name unless self.context["tag"][category].include?(tag.classification.name)


### PR DESCRIPTION
fixes https://github.com/miq-consumption/manageiq-consumption/issues/53

tagging mechanism is used also for other things then 
tagging objects in Miq and for this reasons are used only managed tags.


cc @sergio-ocon @aljesusg 