### PR TITLE
Adding minimum_step unit and value

### DIFF
--- a/app/helpers/manageiq/consumption/time_converter_helper.rb
+++ b/app/helpers/manageiq/consumption/time_converter_helper.rb
@@ -10,7 +10,7 @@ module ManageIQ::Consumption
   module TimeConverterHelper
     VALID_INTERVAL_UNITS = %w(hourly daily weekly monthly yearly).freeze
 
-    def self.number_of_intervals(period, interval, calculation_date = Time.now)
+    def self.number_of_intervals(period:, interval:, calculation_date: Time.now, days_in_month: nil, days_in_year: nil)
       # Period: time period as input (end_time - start_time)
       # interval: base interval to calculate against (i.e 'daily', 'monthly', default: 'monthly')
       # Calculation_date: used to calculate taking into account the #days in month
@@ -21,8 +21,8 @@ module ManageIQ::Consumption
                   when 'hourly'   then 1.hour.seconds
                   when 'daily'    then 1.day.seconds
                   when 'weekly'   then 1.week.seconds
-                  when 'monthly'  then Time.days_in_month(calculation_date.month) * 1.day.seconds
-                  when 'yearly'   then Time.days_in_year(calculation_date.year) * 1.day.seconds
+                  when 'monthly'  then (days_in_month || Time.days_in_month(calculation_date.month)) * 1.day.seconds
+                  when 'yearly'   then (days_in_year || Time.days_in_year(calculation_date.year)) * 1.day.seconds
                   end
       period.div(time_span) + (period.modulo(time_span).zero? ? 0 : 1)
     end

--- a/app/models/manageiq/consumption/showback_price_plan.rb
+++ b/app/models/manageiq/consumption/showback_price_plan.rb
@@ -15,7 +15,7 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
   ###################################################################
   def calculate_total_cost(event, cycle_duration = nil)
     total = 0
-    calculate_list_of_costs(event,  cycle_duration).each do |x|
+    calculate_list_of_costs(event, cycle_duration).each do |x|
       total += x[0]
     end
     total
@@ -32,7 +32,7 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
       usage.dimensions.each do |dim|
         rates = showback_rates.where(category: usage.category, measure: usage.measure, dimension: dim)
         rates.each do |r|
-          next unless (ManageIQ::Consumption::DataUtilsHelper.is_included_in? event.context, r.screener)
+          next unless ManageIQ::Consumption::DataUtilsHelper.is_included_in?(event.context, r.screener)
           tc << [r.rate(event, cycle_duration), r]
         end
       end
@@ -42,7 +42,12 @@ class ManageIQ::Consumption::ShowbackPricePlan < ApplicationRecord
 
 
   # Calculate total costs using input data instead of an event
-  def calculate_total_cost_input(resource_type, data, context = nil, start_time = nil, end_time = nil, cycle_duration = nil)
+  def calculate_total_cost_input(resource_type:,
+                                 data:,
+                                 context: nil,
+                                 start_time: nil,
+                                 end_time: nil,
+                                 cycle_duration: nil)
     event = ManageIQ::Consumption::ShowbackEvent.new
     event.resource_type = resource_type
     event.data = data

--- a/app/models/manageiq/consumption/showback_rate.rb
+++ b/app/models/manageiq/consumption/showback_rate.rb
@@ -40,7 +40,12 @@ module ManageIQ::Consumption
       duration = cycle_duration || event.month_duration
       # TODO event.resource.type should be eq to category
       value, measurement = event.get_measure(measure, dimension)
-      rate_with_values(value, measurement,event.time_span, duration)
+       # Convert step and value to the same unit (variable_rate_per_unit, and create the minimum step)
+      adjusted_step = UnitsConverterHelper.to_unit(step_value, step_unit, variable_rate_per_unit)
+      divmod = UnitsConverterHelper.to_unit(value, measurement, variable_rate_per_unit).divmod adjusted_step
+      adjusted_value = (divmod[0] + (divmod[1].zero? ? 0 : 1)) * adjusted_step
+      adjusted_time_span = event.time_span
+      rate_with_values(adjusted_value, variable_rate_per_unit,adjusted_time_span, duration)
     end
 
     def rate_with_values(value, measure, time_span, cycle_duration, date = Time.current)

--- a/app/models/manageiq/consumption/showback_rate.rb
+++ b/app/models/manageiq/consumption/showback_rate.rb
@@ -53,7 +53,7 @@ module ManageIQ::Consumption
       end
       # If there is a step time defined, we use it to adjust input to it
       adjusted_time_span = event.time_span
-      rate_with_values(adjusted_value, measurement,adjusted_time_span, duration)
+      rate_with_values(adjusted_value, measurement, adjusted_time_span, duration)
     end
 
     def rate_with_values(value, measure, time_span, cycle_duration, date = Time.current)

--- a/spec/factories/showback_rate.rb
+++ b/spec/factories/showback_rate.rb
@@ -40,5 +40,11 @@ FactoryGirl.define do
       dimension 'max_number_of_cpu'
       variable_rate_per_unit 'cores'
     end
+
+    trait :MEM_max_mem do
+      measure 'MEM'
+      dimension 'max_mem'
+      variable_rate_per_unit 'Mib'
+    end
   end
 end

--- a/spec/models/showback_pool_spec.rb
+++ b/spec/models/showback_pool_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
   before(:all) do
     ManageIQ::Consumption::ShowbackUsageType.seed
   end
-  let(:resource)        { FactoryGirl.create(:vm)}
+  let(:resource)        { FactoryGirl.create(:vm) }
   let(:pool)            { FactoryGirl.build(:showback_pool) }
   let(:event)           { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, resource: resource) }
   let(:event2)          { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, resource: resource) }
@@ -62,7 +62,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
     it 'it only can be in approved states' do
       pool.state = 'ERROR'
       expect(pool).not_to be_valid
-      expect(pool.errors.details[:state]).to include({:error => :inclusion, :value => 'ERROR'})
+      expect(pool.errors.details[:state]).to include(:error => :inclusion, :value => 'ERROR')
     end
 
     it 'it can not be different of states open, processing, closed' do
@@ -82,7 +82,6 @@ RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
 
   context '.control lifecycle state' do
     let(:pool_lifecycle) { FactoryGirl.create(:showback_pool) }
-
 
     it 'it can transition from open to processing' do
       pool_lifecycle.state = 'PROCESSING'
@@ -230,16 +229,16 @@ RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
       enterprise_plan
       FactoryGirl.create(:showback_rate,
                          :CPU_average,
-                         :fixed_rate => Money.new(67),
-                         :variable_rate => Money.new(12),
+                         :fixed_rate          => Money.new(67),
+                         :variable_rate       => Money.new(12),
                          :showback_price_plan => enterprise_plan)
       pool.add_event(event2)
       # event2.reload
       pool.showback_charges.reload
       charge = pool.showback_charges.find_by(:showback_event => event2)
       charge.cost = Money.new(0)
-      expect { pool.calculate_charge(charge) }.to change(charge, :cost).
-          from(Money.new(0)).to(Money.new((event2.reload.get_measure_value('CPU','average') * 12) + 67))
+      expect { pool.calculate_charge(charge) }.to change(charge, :cost)
+        .from(Money.new(0)).to(Money.new((event2.reload.get_measure_value('CPU', 'average') * 12) + 67))
     end
 
     it '#Add an event' do
@@ -290,8 +289,8 @@ RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
       vm = FactoryGirl.create(:vm)
       FactoryGirl.create(:showback_rate,
                          :CPU_average,
-                         :fixed_rate => Money.new(67),
-                         :variable_rate => Money.new(12),
+                         :fixed_rate          => Money.new(67),
+                         :variable_rate       => Money.new(12),
                          :showback_price_plan => ManageIQ::Consumption::ShowbackPricePlan.first)
       ev = FactoryGirl.create(:showback_event, :with_vm_data, :full_month, resource: vm)
       ev2 = FactoryGirl.create(:showback_event, :with_vm_data, :full_month, resource: vm)

--- a/spec/models/showback_price_plan_spec.rb
+++ b/spec/models/showback_price_plan_spec.rb
@@ -88,8 +88,12 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         start_time = event.start_time
         end_time = event.end_time
         context = event.context
-        expect(plan.calculate_total_cost_input(resource_type, data, context, start_time, end_time)).to eq(plan.calculate_total_cost(event))
-        expect(plan.calculate_total_cost_input(resource_type, data)).to eq(plan.calculate_total_cost(event))
+        expect(plan.calculate_total_cost_input(resource_type: resource_type,
+                                               data: data,
+                                               context: context,
+                                               start_time: start_time,
+                                               end_time: end_time)).to eq(plan.calculate_total_cost(event))
+        expect(plan.calculate_total_cost_input(resource_type: resource_type, data: data)).to eq(plan.calculate_total_cost(event))
       end
 
       it 'calculates costs when rate is not found and default event data' do
@@ -97,7 +101,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         rate.save
         resource_type = event.resource.type
         data = event.data
-        expect(plan.calculate_total_cost_input(resource_type, data)).to eq(plan.calculate_total_cost(event))
+        expect(plan.calculate_total_cost_input(resource_type: resource_type, data: data)).to eq(plan.calculate_total_cost(event))
       end
 
       it 'test that data is right' do

--- a/spec/models/showback_price_plan_spec.rb
+++ b/spec/models/showback_price_plan_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
 
     context 'rating with context' do
       let(:resource)      { FactoryGirl.create(:vm) }
-      let(:event)         { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, :with_tags_in_context, resource: resource) }
+      let(:event)         { FactoryGirl.build(:showback_event, :with_vm_data, :full_month, :with_tags_in_context, :resource => resource) }
       let(:fixed_rate)    { Money.new(11) }
       let(:variable_rate) { Money.new(7) }
       let(:plan)  { FactoryGirl.create(:showback_price_plan) }
@@ -192,9 +192,8 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         event.reload
         rate2.save
         # Rating now should return the value
-        expect(plan.calculate_list_of_costs(event)).to  match_array([[rate2.rate(event), rate2]])
+        expect(plan.calculate_list_of_costs(event)).to match_array([[rate2.rate(event), rate2]])
       end
-
 
       it 'calculates costs when more than one rate applies' do
         event.save
@@ -211,9 +210,8 @@ RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
         rate.save
         rate2.save
         # Rating now should return the value
-        expect(plan.calculate_list_of_costs(event)).to  match_array([[rate.rate(event), rate], [rate2.rate(event), rate2]])
+        expect(plan.calculate_list_of_costs(event)).to match_array([[rate.rate(event), rate], [rate2.rate(event), rate2]])
       end
-
     end
   end
 

--- a/spec/models/showback_rate_spec.rb
+++ b/spec/models/showback_rate_spec.rb
@@ -246,17 +246,21 @@ module ManageIQ::Consumption
           showback_rate.step_unit = 'Gib'
           expect(showback_rate.rate(showback_event_fm)).to eq(Money.new(11 + 7 * 4096))
 
-          showback_event_fm.data["MEM"]["max_mem"][0] = 512
+          # Modify the input data so the data is not a multiple
+          showback_event_fm.data["MEM"]["max_mem"][0] = 501
           showback_event_fm.data["MEM"]["max_mem"][1] = 'MiB'
           showback_rate.step_unit = 'MiB'
           showback_rate.step_value = 384
           expect(showback_rate.rate(showback_event_fm)).to eq(Money.new(11 + 7 * 384 * 2))
-
-
         end
 
         pending 'step time moves half_month to full_month' do
-
+          showback_rate.step_unit = 'b'
+          showback_rate.step_value = 1
+          showback_rate.step_time_value = 1
+          showback_rate.step_time_unit = 'month'
+          showback_rate.calculation = 'duration'
+          expect(showback_rate.rate(showback_event_hm)).to eq(showback_rate.rate(showback_event_fm))
         end
 
         pending 'step is not a subunit of the tier' do

--- a/spec/models/showback_rate_spec.rb
+++ b/spec/models/showback_rate_spec.rb
@@ -143,13 +143,13 @@ module ManageIQ::Consumption
       end
 
       it 'is valid with a JSON screener' do
-        showback_rate.screener = JSON.generate({ 'tag' => { 'environment' => ['test'] } })
+        showback_rate.screener = JSON.generate('tag' => { 'environment' => ['test'] })
         showback_rate.valid?
         expect(showback_rate).to be_valid
       end
 
       pending 'is not valid with a wronly formatted screener' do
-        showback_rate.screener = JSON.generate({ 'tag' => { 'environment' => ['test'] } })
+        showback_rate.screener = JSON.generate('tag' => { 'environment' => ['test'] })
         showback_rate.valid?
         expect(showback_rate).not_to be_valid
       end
@@ -164,12 +164,12 @@ module ManageIQ::Consumption
     describe 'when the event lasts for the full month and the rates too' do
       let(:fixed_rate)    { Money.new(11) }
       let(:variable_rate) { Money.new(7) }
-      let(:showback_rate) {
+      let(:showback_rate) do
         FactoryGirl.build(:showback_rate,
                           :CPU_number,
-                          :fixed_rate => fixed_rate,
+                          :fixed_rate    => fixed_rate,
                           :variable_rate => variable_rate)
-                          }
+      end
       let(:showback_event_fm) { FactoryGirl.build(:showback_event, :full_month, :with_vm_data) }
 
       context 'empty #context, default rate per_time and per_unit' do
@@ -198,12 +198,12 @@ module ManageIQ::Consumption
       context 'minimum step' do
         let(:fixed_rate)    { Money.new(11) }
         let(:variable_rate) { Money.new(7) }
-        let(:showback_rate) {
+        let(:showback_rate) do
           FactoryGirl.build(:showback_rate,
                             :MEM_max_mem,
-                            :fixed_rate => fixed_rate,
+                            :fixed_rate    => fixed_rate,
                             :variable_rate => variable_rate)
-        }
+        end
         let(:showback_event_fm) { FactoryGirl.build(:showback_event, :full_month, :with_vm_data) }
         let(:showback_event_hm) { FactoryGirl.build(:showback_event, :first_half_month, :with_vm_data) }
         it 'nil step should behave like no step' do
@@ -314,9 +314,7 @@ module ManageIQ::Consumption
           expect(showback_rate.rate(showback_event_fm)).to eq(Money.new(11 + (2048 * 1024 * 7)))
         end
 
-        it 'should charge an event by quantity' do
-
-        end
+        pending 'should charge an event by quantity'
       end
 
       context 'tiered on input value' do
@@ -335,12 +333,12 @@ module ManageIQ::Consumption
     describe 'event lasts the first 15 days and the rate is monthly' do
       let(:fixed_rate)    { Money.new(11) }
       let(:variable_rate) { Money.new(7) }
-      let(:showback_rate) {
+      let(:showback_rate) do
         FactoryGirl.build(:showback_rate,
                           :CPU_number,
-                          :fixed_rate => fixed_rate,
+                          :fixed_rate    => fixed_rate,
                           :variable_rate => variable_rate)
-      }
+      end
       let(:showback_event_hm) { FactoryGirl.build(:showback_event, :first_half_month, :with_vm_data) }
       let(:proration)         { showback_event_hm.time_span.to_f / showback_event_hm.month_duration }
 
@@ -357,7 +355,7 @@ module ManageIQ::Consumption
 
         it 'should charge an event by quantity' do
           showback_rate.calculation = 'quantity'
-        # Fixed is 11 per day, variable is 7 per CPU, event has 2 CPU
+          # Fixed is 11 per day, variable is 7 per CPU, event has 2 CPU
           expect(showback_rate.rate(showback_event_hm)).to eq(Money.new(11 + 7 * 2))
         end
       end


### PR DESCRIPTION
Adding steps to rating.

When the step is nil, the rating is done without taking it into account.
When a minimum step is defined, the input value is rounded to the step

Example: input is 511 MB,  minimum step is 1GB, input is considered to be 1GB

Minimum step should not modify the tier the rate is being applied to (i.e. it should be possible to divide the tier upper level by the step)

TODO: Another PR should add support for minimum_step_per_time, currently only input value is supported