### PR TITLE
Change Travis to manageiq/manageiq-consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Miq-Consumption
 [![Gem Version](https://badge.fury.io/rb/manageiq-consumption.svg)](https://badge.fury.io/rb/manageiq-consumption)
-[![Build Status](https://travis-ci.org/miq-consumption/manageiq-consumption.svg)](https://travis-ci.org/miq-consumption/manageiq-consumption)
-[![Code Climate](https://codeclimate.com/github/miq-consumption/manageiq-consumption.svg)](https://codeclimate.com/github/miq-consumption/manageiq-consumption)
-[![Coverage Status](https://coveralls.io/repos/github/miq-consumption/manageiq-consumption/badge.svg?branch=master)](https://coveralls.io/github/miq-consumption/manageiq-consumption?branch=master)
-[![Dependency Status](https://gemnasium.com/badges/github.com/miq-consumption/manageiq-consumption.svg)](https://gemnasium.com/github.com/miq-consumption/manageiq-consumption)
-[![security](https://hakiri.io/github/miq-consumption/manageiq-consumption/master.svg)](https://hakiri.io/github/miq-consumption/manageiq-consumption/master)
-[![Gitter](https://badges.gitter.im/miq-consumption/manageiq-consumption.svg)](https://gitter.im/miq-consumption/manageiq-consumption?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
+[![Build Status](https://travis-ci.org/ManageIQ/manageiq-consumption.svg)](https://travis-ci.org/ManageIQ/manageiq-consumption)
+[![Coverage Status](https://coveralls.io/repos/github/ManageIQ/manageiq-consumption/badge.svg?branch=master)](https://coveralls.io/github/ManageIQ/manageiq-consumption?branch=master)[![Dependency Status](https://gemnasium.com/badges/github.com/ManageIQ/manageiq-consumption.svg)](https://gemnasium.com/github.com/miq-consumption/manageiq-consumption)
+[![Gitter](https://badges.gitter.im/ManageIQ/manageiq/chargeback.svg)](https://gitter.im/ManageIQ/manageiq/chargeback?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Build history for master branch](https://buildstats.info/travisci/chart/ManageIQ/manageiq-consumption?branch=master&buildCount=50)](https://travis-ci.org/ManageIQ/manageiq-consumption/branches)
 
 ManageIQ Gem plugin for the Consumption.
 


### PR DESCRIPTION
Change the README badges for new travis

Removed codeclimate, gemnasium and hakiri, need admin settings