### PR TITLE
Change before :all to :each so it's rolled back

### DIFF
--- a/spec/models/showback_charge_spec.rb
+++ b/spec/models/showback_charge_spec.rb
@@ -3,7 +3,7 @@ require 'money-rails/test_helpers'
 
 RSpec.describe ManageIQ::Consumption::ShowbackCharge, :type => :model do
 
-  before(:all) do
+  before(:each) do
     ManageIQ::Consumption::ShowbackUsageType.seed
   end
 

--- a/spec/models/showback_pool_spec.rb
+++ b/spec/models/showback_pool_spec.rb
@@ -3,7 +3,7 @@ require 'money-rails/test_helpers'
 
 RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
 
-  before(:all) do
+  before(:each) do
     ManageIQ::Consumption::ShowbackUsageType.seed
   end
   let(:resource)        { FactoryGirl.create(:vm) }

--- a/spec/models/showback_price_plan_spec.rb
+++ b/spec/models/showback_price_plan_spec.rb
@@ -3,7 +3,7 @@ require 'money-rails/test_helpers'
 
 RSpec.describe ManageIQ::Consumption::ShowbackPricePlan, :type => :model do
   # We need to ShowbackUsageType list to know what measures we should be looking for
-  before(:all) do
+  before(:each) do
     ManageIQ::Consumption::ShowbackUsageType.seed
   end
 

--- a/spec/models/showback_rate_spec.rb
+++ b/spec/models/showback_rate_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'money-rails/test_helpers'
 module ManageIQ::Consumption
   describe ShowbackRate do
-    before(:all) do
+    before(:each) do
       ShowbackUsageType.seed
     end
     describe 'model validations' do

--- a/spec/models/showback_usage_type_spec.rb
+++ b/spec/models/showback_usage_type_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 require 'money-rails/test_helpers'
 
 describe ManageIQ::Consumption::ShowbackUsageType do
-  before(:all) do
-    @expected_showback_usage_type_count = 6
-  end
-
   before(:each) do
     ManageIQ::Consumption::ShowbackUsageType.delete_all
   end
@@ -69,15 +65,17 @@ describe ManageIQ::Consumption::ShowbackUsageType do
   end
 
   context ".seed" do
+    let(:expected_showback_usage_type_count) { 6 }
+
     it "empty table" do
       described_class.seed
-      expect(described_class.count).to eq(@expected_showback_usage_type_count)
+      expect(described_class.count).to eq(expected_showback_usage_type_count)
     end
 
     it "run twice" do
       described_class.seed
       described_class.seed
-      expect(described_class.count).to eq(@expected_showback_usage_type_count)
+      expect(described_class.count).to eq(expected_showback_usage_type_count)
     end
   end
 end


### PR DESCRIPTION
before(:each) runs in a transaction, while :all does not.  The latter
needs to be manually rolled back and is a source of strange test
failures if you don't do it correctly.  The tests run nearly as fast, so
it's not worth it to use before all.