### PR TITLE
Add US8 currency

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -4,7 +4,6 @@ MoneyRails.configure do |config|
 
   # To set the default currency
   #
-  config.default_currency = :usd
 
   # Set default bank object
   #
@@ -40,7 +39,7 @@ MoneyRails.configure do |config|
                              type: :string,
                              present: true,
                              null: false,
-                             default: 'USD'
+                             default: 'US8'
                            }
 
   config.register_currency = {
@@ -57,6 +56,8 @@ MoneyRails.configure do |config|
 
   config.add_rate "USD", "US8", 1
   config.add_rate "US8", "USD", 1
+
+  config.default_currency = :us8
 
   # Register a custom currency
   #

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -43,6 +43,21 @@ MoneyRails.configure do |config|
                              default: 'USD'
                            }
 
+  config.register_currency = {
+      :priority            => 1,
+      :iso_code            => :us8,
+      :name                => "US Dollar with subunit of 8 digits",
+      :symbol              => "$",
+      :symbol_first        => true,
+      :subunit             => "Subcent",
+      :subunit_to_unit     => 100_000_000,
+      :thousands_separator => ",",
+      :decimal_mark        => "."
+  }
+
+  config.add_rate "USD", "US8", 1
+  config.add_rate "US8", "USD", 1
+
   # Register a custom currency
   #
   # Example:

--- a/spec/models/showback_tier_spec.rb
+++ b/spec/models/showback_tier_spec.rb
@@ -23,16 +23,16 @@ RSpec.describe ManageIQ::Consumption::ShowbackTier, :type => :model do
 
     it 'has a Money fixed_rate' do
       expect(described_class).to monetize(:fixed_rate)
-      ch = FactoryGirl.create(:showback_tier, :fixed_rate => Money.new(256, 'USD'))
+      ch = FactoryGirl.create(:showback_tier, :fixed_rate => Money.new(256_000_000, 'US8'))
       expect(ch).to be_valid
-      expect(ch.fixed_rate.format).to eq('$2.56')
+      expect(ch.fixed_rate.exchange_to('USD').format).to eq('$2.56')
     end
 
     it 'has a Money variable_rate' do
       expect(described_class).to monetize(:variable_rate)
-      ch = FactoryGirl.create(:showback_tier, :variable_rate => Money.new(675, 'USD'))
+      ch = FactoryGirl.create(:showback_tier, :variable_rate => Money.new(675_000_000, 'US8'))
       expect(ch).to be_valid
-      expect(ch.variable_rate.format).to eq('$6.75')
+      expect(ch.variable_rate.exchange_to('USD').format).to eq('$6.75')
     end
 
     it '#fixed_rate_per_time included in VALID_INTERVAL_UNITS is valid' do


### PR DESCRIPTION
**1 Cents is 1 00 000 000 SubCent**

@sergio-ocon @aljesusg  Not sure if you aware about this but we need more decimal numbers to keep rates with value, for example, `$0.001` as we have in rate editor. What do you think ?

So I am bringing new unit called `SubCent` for USD currency.
So when we want to say $1 in money it is:
`
Money.new(100_000_000)
Money.new(100_000_000).to_f => "1.0" (in $)
`

Task:
use money gem to interpret amount `$0.001`

Before(not possible):
```ruby
rate = ManageIQ::Consumption::ShowbackTier.create(:variable_rate => Money.new(0.011 * 100, :tier_start_value => 0, :tier_end_value => Float::INFINITY )
rate.variable_rate.to_f # => 0.01, but we need 0.011
```

After:
```ruby
rate = ManageIQ::Consumption::ShowbackTier.create(:variable_rate => Money.new(0.011 * 100_000_000), :tier_start_value => 0, :tier_end_value => Float::INFINITY )
rate.variable_rate.to_f # => 0.011 (in $)
```


cc @gtanzillo 

# Links
https://www.pivotaltracker.com/story/show/147800123
