### PR TITLE
Now rate create a zero tier after create

### DIFF
--- a/app/models/manageiq/consumption/showback_rate.rb
+++ b/app/models/manageiq/consumption/showback_rate.rb
@@ -18,8 +18,14 @@ module ManageIQ::Consumption
     default_value_for :screener, { }
     validates :screener, :exclusion => { :in => [nil] }
 
+    after_create :create_zero_tier
+
     def name
       "#{category}:#{measure}:#{dimension}"
+    end
+
+    def create_zero_tier
+      ManageIQ::Consumption::ShowbackTier.create(:tier_start_value => 0,:tier_end_value => Float::INFINITY, :showback_rate => self)
     end
 
     def rate(event, cycle_duration = nil)

--- a/spec/factories/showback_rate.rb
+++ b/spec/factories/showback_rate.rb
@@ -8,10 +8,6 @@ FactoryGirl.define do
     calculation            'duration'
     showback_price_plan
 
-    after(:build) do |x|
-      create(:showback_tier,:with_rate_tests, :showback_rate => x)
-    end
-
     trait :occurrence do
       calculation 'occurrence'
     end

--- a/spec/models/showback_pool_spec.rb
+++ b/spec/models/showback_pool_spec.rb
@@ -294,11 +294,11 @@ RSpec.describe ManageIQ::Consumption::ShowbackPool, :type => :model do
       sh = FactoryGirl.create(:showback_rate,
                               :CPU_average,
                               :showback_price_plan => ManageIQ::Consumption::ShowbackPricePlan.first)
-      FactoryGirl.create(:showback_tier,
-                         :showback_rate => sh,
-                         :fixed_rate          => Money.new(67),
-                         :variable_rate       => Money.new(12))
-      ev = FactoryGirl.create(:showback_event, :with_vm_data, :full_month, resource: vm)
+      tier = sh.showback_tiers.first
+      tier.fixed_rate    = Money.new(67)
+      tier.variable_rate = Money.new(12)
+      tier.save
+      ev  = FactoryGirl.create(:showback_event, :with_vm_data, :full_month, resource: vm)
       ev2 = FactoryGirl.create(:showback_event, :with_vm_data, :full_month, resource: vm)
       pool.add_event(ev)
       pool.add_event(ev2)


### PR DESCRIPTION
Now when we create a Rate has a "Zero initial" tier from 0 to Infinite

ManageIQ::Consumption::ShowbackTier.create(:tier_start_value => 0,:tier_end_value => Float::INFINITY, :showback_rate => self)

We need this for **tiers**