### PR TITLE
Add missing usage types for integration

### DIFF
--- a/app/models/manageiq/consumption/showback_column_units.yml
+++ b/app/models/manageiq/consumption/showback_column_units.yml
@@ -22,3 +22,4 @@
 :fixed_compute_2: ""
 :fixed_storage_1: ""
 :fixed_storage_2: ""
+:metering_used_hours: ""

--- a/app/models/manageiq/consumption/showback_column_units.yml
+++ b/app/models/manageiq/consumption/showback_column_units.yml
@@ -23,3 +23,5 @@
 :fixed_storage_1: ""
 :fixed_storage_2: ""
 :metering_used_hours: ""
+:derived_vm_allocated_disk_storage: "Gi"
+:derived_vm_used_disk_storage: "Gi"

--- a/app/models/manageiq/consumption/showback_event/cpu.rb
+++ b/app/models/manageiq/consumption/showback_event/cpu.rb
@@ -38,4 +38,10 @@ module ManageIQ::Consumption::ShowbackEvent::CPU
 
   def cpu_cores_derived_vm_numvcpus
   end
+
+  def cpu_cores_cpu_usage_rate_average
+  end
+
+  def cpu_derived_vm_numvcpus
+  end
 end

--- a/app/models/manageiq/consumption/showback_event/metering.rb
+++ b/app/models/manageiq/consumption/showback_event/metering.rb
@@ -1,0 +1,5 @@
+module ManageIQ::Consumption::ShowbackEvent::METERING
+  # for old chargeback integration
+  def metering_metering_used_hours
+  end
+end

--- a/app/models/manageiq/consumption/showback_event/storage.rb
+++ b/app/models/manageiq/consumption/showback_event/storage.rb
@@ -1,0 +1,8 @@
+module ManageIQ::Consumption::ShowbackEvent::STORAGE
+  # for old chargeback integration
+  def storage_derived_vm_used_disk_storage
+  end
+
+  def storage_derived_vm_allocated_disk_storage
+  end
+end

--- a/app/models/manageiq/consumption/showback_rate.rb
+++ b/app/models/manageiq/consumption/showback_rate.rb
@@ -82,7 +82,7 @@ module ManageIQ::Consumption
       return Money.new(0) unless value # If value is null, the event is not present and thus we return 0
       fix_inter = TimeConverterHelper.number_of_intervals(period: cycle_duration, interval: tier.fixed_rate_per_time, calculation_date: date)
       var_inter = TimeConverterHelper.number_of_intervals(period: cycle_duration, interval: tier.variable_rate_per_time, calculation_date: date)
-      value_in_rate_units = UnitsConverterHelper.to_unit(value, measure, tier.variable_rate_per_unit) || 0
+      value_in_rate_units = UnitsConverterHelper.to_unit(value.to_f, measure, tier.variable_rate_per_unit) || 0
       ((fix_inter * tier.fixed_rate) + (var_inter * value_in_rate_units * tier.variable_rate)) * time_span.to_f / cycle_duration
     end
 

--- a/db/fixtures/showback_usage_types.yml
+++ b/db/fixtures/showback_usage_types.yml
@@ -31,7 +31,7 @@
 - :category: "Container"
   :description: "TBD"
   :measure: "cpu_cores"
-  :dimensions: ["v_derived_cpu_total_cores_used", "derived_vm_numvcpus"]
+  :dimensions: ["v_derived_cpu_total_cores_used", "derived_vm_numvcpus", "cpu_usage_rate_average"]
 - :category: "Container"
   :description: "TBD"
   :measure: "memory"
@@ -48,3 +48,69 @@
   :description: "TBD"
   :measure: "fixed"
   :dimensions: ["fixed_compute_1", "fixed_compute_2", "fixed_storage_1", "fixed_storage_2"]
+  
+- :category: "Container"
+  :description: "TBD"
+  :measure: "metering"
+  :dimensions: ["metering_used_hours"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "cpu"
+  :dimensions: ["cpu_usagemhz_rate_average"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "cpu_cores"
+  :dimensions: ["v_derived_cpu_total_cores_used", "derived_vm_numvcpus", "cpu_usage_rate_average"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "memory"
+  :dimensions: ["derived_memory_used", "derived_memory_available"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "net_io"
+  :dimensions: ["net_usage_rate_average"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "disk_io"
+  :dimensions: ["disk_usage_rate_average"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "fixed"
+  :dimensions: ["fixed_compute_1", "fixed_compute_2", "fixed_storage_1", "fixed_storage_2"]
+- :category: "ContainerImage"
+  :description: "TBD"
+  :measure: "metering"
+  :dimensions: ["metering_used_hours"]
+
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "cpu"
+  :dimensions: ["derived_vm_numvcpus", "cpu_usagemhz_rate_average"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "cpu_cores"
+  :dimensions: ["v_derived_cpu_total_cores_used", "cpu_usage_rate_average"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "memory"
+  :dimensions: ["derived_memory_used", "derived_memory_available"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "net_io"
+  :dimensions: ["net_usage_rate_average"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "disk_io"
+  :dimensions: ["disk_usage_rate_average"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "fixed"
+  :dimensions: ["fixed_compute_1", "fixed_compute_2", "fixed_storage_1", "fixed_storage_2", "fixed_storage_2", "fixed_storage_1"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "metering"
+  :dimensions: ["metering_used_hours"]
+- :category: "Vm"
+  :description: "TBD"
+  :measure: "storage"
+  :dimensions: ["derived_vm_allocated_disk_storage", "derived_vm_used_disk_storage"]

--- a/spec/models/showback_usage_type_spec.rb
+++ b/spec/models/showback_usage_type_spec.rb
@@ -65,7 +65,7 @@ describe ManageIQ::Consumption::ShowbackUsageType do
   end
 
   context ".seed" do
-    let(:expected_showback_usage_type_count) { 12 }
+    let(:expected_showback_usage_type_count) { 28 }
 
     it "empty table" do
       described_class.seed


### PR DESCRIPTION
we initially added just couple types https://github.com/ManageIQ/manageiq-consumption/pull/95/commits/3a8008f5e7baa992e9f204dbdfd2eca5857ceed4
so there is rest

cc @sergio-ocon @aljesusg 
@miq-bot assign @gtanzillo 
