### PR TITLE
Tighten the money-rails dependency

### DIFF
--- a/manageiq-consumption.gemspec
+++ b/manageiq-consumption.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,lib,spec}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-
-  spec.add_dependency "money-rails", "~>1"
+  spec.add_dependency "money-rails", "~> 1.9"
 
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
According to semver, ~>1 will bring in 2.0, if it is released, which is
a breaking version, so this avoids that.  Use 1.9.0 since this is new
code and we should just use the latest gem.

@chargio Please review.