### PR TITLE
Remove deprecation warning `use_i18n` is deprecated

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,4 +1,5 @@
 # encoding : utf-8
+Money.locale_backend = :i18n
 
 MoneyRails.configure do |config|
 


### PR DESCRIPTION
```
[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead
```

is messing up travis:
https://travis-ci.org/ManageIQ/manageiq/jobs/445891003

Tested on master:
https://github.com/ManageIQ/manageiq/pull/18134


inspired by https://github.com/RubyMoney/money/issues/816

