### PR TITLE
Use Timecop to freeze current times in specs

### DIFF
--- a/spec/helpers/time_converter_helper_spec.rb
+++ b/spec/helpers/time_converter_helper_spec.rb
@@ -11,6 +11,16 @@ require 'spec_helper'
 # end
 
 RSpec.describe ManageIQ::Showback::TimeConverterHelper, :type => :helper do
+  let(:time_current) { Time.parse('Mon, 05 Nov 2018 18:39:38 UTC +00:00').utc }
+
+  before do
+    Timecop.travel(time_current)
+  end
+
+  after do
+    Timecop.return
+  end
+
   let(:constants) do
     [described_class::VALID_INTERVAL_UNITS]
   end

--- a/spec/helpers/time_converter_helper_spec.rb
+++ b/spec/helpers/time_converter_helper_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe ManageIQ::Showback::TimeConverterHelper, :type => :helper do
 
     it 'weekly' do
       interval = 'weekly'
-      results = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 5]
+      results = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 5, 4]
+      time_values.push(28.days)
       expect(results.length).to eq(time_values.length)
       start_t = Time.current.beginning_of_month
       time_values.each_with_index do |x, y|

--- a/spec/models/rate_spec.rb
+++ b/spec/models/rate_spec.rb
@@ -2,9 +2,21 @@ require 'spec_helper'
 require 'money-rails/test_helpers'
 module ManageIQ::Showback
   describe Rate do
+    let(:time_current) { Time.parse('Tue, 05 Feb 2019 18:53:19 UTC +00:00').utc }
+
+    before do
+      Timecop.travel(time_current)
+    end
+
     before(:each) do
+      Timecop.travel(time_current)
       InputMeasure.seed
     end
+
+    after do
+      Timecop.return
+    end
+
     describe 'model validations' do
       let(:rate) { FactoryBot.build(:rate) }
 


### PR DESCRIPTION
fixing  _**"February"**_  CI failure   https://travis-ci.org/ManageIQ/manageiq-consumption
math here doesn't work with month with 28 days, so I froze it with Timecop

@miq-bot assign @jrafanie 
@miq-bot add_label bug
cc @gtanzillo 