### PR TITLE
move hashdiff from core to here - removing dependency

### DIFF
--- a/app/helpers/manageiq/showback/utils_helper.rb
+++ b/app/helpers/manageiq/showback/utils_helper.rb
@@ -6,7 +6,7 @@ module ManageIQ::Showback
       return false if test.nil? || context.nil?
       result = true
       test = {} if test.empty?
-      HashDiff.diff(context, test).each do |x|
+      Hashdiff.diff(context, test).each do |x|
         result = false if x[0] == '+' || x[0] == '~'
       end
       result

--- a/manageiq-consumption.gemspec
+++ b/manageiq-consumption.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,lib,spec}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   spec.add_dependency "money-rails", "~> 1.9"
+  spec.add_dependency "hashdiff", "~> 0.4.0"
 
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
```
The HashDiff constant used by this gem conflicts with another gem of a similar name. 
As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.
For more information see https://github.com/liufengyun/hashdiff/issues/45
```

followup: removed dependency from core in https://github.com/ManageIQ/manageiq/pull/18881