### PR TITLE
[HAMMER] State the version of hashdiff gem required

### DIFF
--- a/manageiq-consumption.gemspec
+++ b/manageiq-consumption.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,lib,spec}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   spec.add_dependency "money-rails", "~> 1.9"
+  spec.add_dependency "hashdiff", "~> 0.3.7"
 
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
Hammer Gemfile specifies a requirement for hashdiff but does not specify a version.
When Hammer uses hashdiff 0.3.7, things work.
Later versions of hashdiff cause problems

In Ivanchuck, we removed the reference to hashdiff from core (manageiq/manageiq) and added it to manageiq-consumption. In consumption we updated the code and locked the version down to a version that works (0.4.0).

For Hammer, we are going to lock down manageiq-consumption to the previous version, 0.3.7
The core still references hashdiff, but since it is not locked down, it will defer the version number to the one specified in manageiq-consumption.
