### PR TITLE
Switch find_by_* to lookup_by_*

### DIFF
--- a/app/models/manageiq/showback/data_rollup.rb
+++ b/app/models/manageiq/showback/data_rollup.rb
@@ -168,7 +168,7 @@ module ManageIQ::Showback
     def assign_by_tag
       return unless context.key?("tag")
       context["tag"].each do |entity, array_children|
-        t = Tag.find_by_classification_name(entity)
+        t = Tag.lookup_by_classification_name(entity)
         find_envelope(t)&.add_data_rollup(self)
         array_children.each do |child_entity|
           tag_child = t.classification.children.detect { |c| c.name == child_entity }


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_.
Switching the callers in this repo to the lookup_by_ methods.

Depend on ManageIQ/manageiq#19313