### PR TITLE
hashdiff 1.0 gem removes/resolve constant warning

### DIFF
--- a/manageiq-consumption.gemspec
+++ b/manageiq-consumption.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,lib,spec}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   spec.add_dependency "money-rails", "~> 1.9"
-  spec.add_dependency "hashdiff", "~> 0.4.0"
+  spec.add_dependency "hashdiff", "~> 1.0"
 
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
From: https://github.com/bblimke/webmock/issues/822

"Due to this issue: liufengyun/hashdiff#45 hashdiff will be removing its current constant in the 1.0 release. Due to webmock's popularity I thought it prudent to let you all know considering your gemspec does not currently have a pessimistic lock on that gem.

The upgrade path is extremely simple. A find and replace in the project from HashDiff to Hashdiff will work exactly the same as before. No require path changes are necessary."

We fixed this in https://github.com/ManageIQ/manageiq-consumption/pull/161 but didn't enforce hashdiff 1.0, which removed/renamed the constant and doesn't evoke the warning:

```
The HashDiff constant used by this gem conflicts with another gem of a similar name.
As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.
For more information see https://github.com/liufengyun/hashdiff/issues/45
```