### PR TITLE
Use dynamic factory bot attributes instead of static

### DIFF
--- a/spec/factories/data_view.rb
+++ b/spec/factories/data_view.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :data_view, :class => ManageIQ::Showback::DataView do
     envelope
     data_rollup
-    cost 0
+    cost { 0 }
     data_snapshot { { } }
     context_snapshot { { } }
 

--- a/spec/factories/envelope.rb
+++ b/spec/factories/envelope.rb
@@ -4,15 +4,15 @@ FactoryBot.define do
     sequence(:description)    { |n| "pool_description_#{seq_padded_for_sorting(n)}" }
     start_time                { 4.hours.ago }
     end_time                  { 1.hour.ago }
-    state                     'OPEN'
+    state                     { 'OPEN' }
     association :resource, :factory => :miq_enterprise, :strategy => :build_stubbed
 
     trait :processing do
-      state 'PROCESSING'
+      state { 'PROCESSING' }
     end
 
     trait :closed do
-      state 'CLOSED'
+      state { 'CLOSED' }
     end
   end
 end

--- a/spec/factories/input_measure.rb
+++ b/spec/factories/input_measure.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :input_measure, :class => ManageIQ::Showback::InputMeasure do
-    entity                   'Vm'
+    entity                   { 'Vm' }
     sequence(:description)   { |s| "Description #{s}" }
-    group                    'CPU'
-    fields                   ['average']
+    group                    { 'CPU' }
+    fields                   { ['average'] }
   end
 end

--- a/spec/factories/rate.rb
+++ b/spec/factories/rate.rb
@@ -1,21 +1,21 @@
 FactoryBot.define do
   factory :rate, :class => ManageIQ::Showback::Rate do
-    entity                 'Vm'
-    field                  'max_number_of_cpu'
-    group                  'CPU'
+    entity                 { 'Vm' }
+    field                  { 'max_number_of_cpu' }
+    group                  { 'CPU' }
     sequence(:concept)     { |n| "Concept #{n}" }
     screener               { {} }
-    calculation            'duration'
+    calculation            { 'duration' }
     price_plan
 
     trait :occurrence do
-      calculation 'occurrence'
+      calculation { 'occurrence' }
     end
     trait :duration do
-      calculation 'duration'
+      calculation { 'duration' }
     end
     trait :quantity do
-      calculation 'quantity'
+      calculation { 'quantity' }
     end
     trait :with_screener do
       screener do
@@ -27,21 +27,21 @@ FactoryBot.define do
       end
     end
     trait :CPU_average do
-      group 'CPU'
-      field 'average'
+      group { 'CPU' }
+      field { 'average' }
     end
     trait :CPU_number do
-      group 'CPU'
-      field 'number'
+      group { 'CPU' }
+      field { 'number' }
     end
     trait :CPU_max_number_of_cpu do
-      group 'CPU'
-      field 'max_number_of_cpu'
+      group { 'CPU' }
+      field { 'max_number_of_cpu' }
     end
 
     trait :MEM_max_mem do
-      group 'MEM'
-      field 'max_mem'
+      group { 'MEM' }
+      field { 'max_mem' }
     end
   end
 end

--- a/spec/factories/tier.rb
+++ b/spec/factories/tier.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :tier, :class => ManageIQ::Showback::Tier do
-    tier_start_value       0
-    tier_end_value         Float::INFINITY
+    tier_start_value       { 0 }
+    tier_end_value         { Float::INFINITY }
     fixed_rate             { Money.new(rand(5..200), 'USD') }
     fixed_rate_per_time    { 'monthly' }
     variable_rate          { Money.new(rand(5..200), 'USD') }
-    variable_rate_per_unit 'cores'
+    variable_rate_per_unit { 'cores' }
     variable_rate_per_time { 'monthly' }
     rate
 


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Static attributes will be removed in FactoryBot
5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block

Note, this is needed to upgrade factory bot here: https://github.com/ManageIQ/manageiq/pull/19338