### PR TITLE
[Rails 5.2] Remove serialize + JSONB calls

### DIFF
--- a/app/models/manageiq/showback/data_rollup.rb
+++ b/app/models/manageiq/showback/data_rollup.rb
@@ -15,10 +15,7 @@ module ManageIQ::Showback
     validate :start_time_before_end_time
     validates :resource, :presence => true
 
-    serialize :data, JSON # Implement data column as a JSON
     default_value_for :data, {}
-
-    serialize :context, JSON
     default_value_for :context, {}
 
     after_create :generate_data

--- a/app/models/manageiq/showback/data_view.rb
+++ b/app/models/manageiq/showback/data_view.rb
@@ -12,9 +12,6 @@ module ManageIQ::Showback
     validates :envelope,    :presence => true, :allow_nil => false
     validates :data_rollup, :presence => true, :allow_nil => false
 
-    serialize :cost, JSON # Implement cost column as a JSON
-    serialize :data_snapshot, JSON # Implement data_snapshot column as a JSON
-    serialize :context_snapshot, JSON # Implement context_snapshot column as a JSON
     before_create :snapshot_data_rollup
     default_value_for :data_snapshot, {}
     default_value_for :context_snapshot, {}

--- a/app/models/manageiq/showback/rate.rb
+++ b/app/models/manageiq/showback/rate.rb
@@ -16,7 +16,6 @@ module ManageIQ::Showback
     validates :group, :presence => true
     default_value_for :group, ''
 
-    serialize :screener, JSON # Implement data column as a JSON
     default_value_for :screener, { }
 
     # Variable uses_single_tier to indicate if the rate only apply in the tier where the value is included


### PR DESCRIPTION
When using serialize, if the database column type is JSONB, then using
serialize is not allowed in Rails 5.2.  With it in place, you end up getting an
error like this:

```
Failure/Error: expect { FactoryBot.create(:rate, :price_plan => plan) }.to change(plan.rates, :count).from(0).to(1)

ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError:
  Column `screener` of type ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb does not support `serialize` feature.
  Usually it means that you are trying to use `serialize`
  on a column that already implements serialization natively.
```

This "should" fix that issue.


Links
-----

- Part of the Rails 5.2 effort: https://github.com/ManageIQ/manageiq/issues/20032