### PR TITLE
[initializers/money.rb] Set rounding_mode

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -33,7 +33,7 @@ MoneyRails.configure do |config|
                             null: false,             # other options will be treated as column options
                             default: 0
                           }
-  
+
   config.currency_column = { prefix: '',
                              postfix: '_currency',
                              column_name: nil,
@@ -88,7 +88,7 @@ MoneyRails.configure do |config|
   #
   # set to BigDecimal::ROUND_HALF_EVEN by default
   #
-  # config.rounding_mode = BigDecimal::ROUND_HALF_UP
+  config.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 
   # Set default money format globally.
   # Default value is nil meaning "ignore this option".


### PR DESCRIPTION
Based on the following error when running the specs:

```
[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN`
to `ROUND_HALF_UP` in the next major release. Set it explicitly using
`Money.rounding_mode=` to avoid potential problems.
```

Simply removes the warning