### PR TITLE
[OPARIN] Lock the oparin release branch to test with ruby 3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
     services:
       postgres:


### PR DESCRIPTION
Lock the oparin release branch to test with ruby 3.0