### PR TITLE
Rails 7 - cpu_usage_rate_average should be a numeric, not a string.

### DIFF
--- a/spec/models/data_rollup_spec.rb
+++ b/spec/models/data_rollup_spec.rb
@@ -223,7 +223,7 @@ describe ManageIQ::Showback::DataRollup do
           }
         }
         expect(data_rollup.start_time.month).to eq(data_rollup.end_time.month)
-        expect(data_rollup.get_group('CPU', 'average')).to eq([data_rollup.resource.metrics.for_time_range(data_rollup.start_time, data_rollup.end_time).average(:cpu_usage_rate_average).to_s, "percent"])
+        expect(data_rollup.get_group('CPU', 'average')).to eq([data_rollup.resource.metrics.for_time_range(data_rollup.start_time, data_rollup.end_time).average(:cpu_usage_rate_average), "percent"])
       end
 
       it 'return nil if field is not found' do


### PR DESCRIPTION
On rails 6.1, the cpu_usage_rate_average was a string, it shouldn't be. On rails 7, it's a numeric.

Note, this will only pass on rails 7 and is included in the core cross repo:

- [x] https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/871

This is ready to go but... it depends on merging the core PR first:
- [x] https://github.com/ManageIQ/manageiq/pull/22873


