### PR TITLE
Use the rails 7.1+ serialize interface

### DIFF
--- a/app/models/manageiq/showback/input_measure.rb
+++ b/app/models/manageiq/showback/input_measure.rb
@@ -2,7 +2,7 @@ module ManageIQ::Showback
   class InputMeasure < ApplicationRecord
     validates :description, :entity, :group, :fields, :presence => true
 
-    serialize :fields, Array
+    serialize :fields, :type => Array
 
     self.table_name = "showback_input_measures"
 


### PR DESCRIPTION
Type was changed from positional to a keyword argument 'type' in 7.1. The positional argument is removed in rails 7.2.

We have a helper bridge module prepending support for either kwargs or positional arguments passed to serialize which converts to positional for rails 7.0 and kwargs for 7.1+.  This was added and automatically loaded in the rails app via the engine in schema:
https://github.com/ManageIQ/manageiq-schema/pull/756

Similar change as core: https://github.com/ManageIQ/manageiq/pull/23253

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
